### PR TITLE
Removing virtual inheritance for DD and fixing build

### DIFF
--- a/Simulator/include/IbInputSimulator/SendTypes/DD.hpp
+++ b/Simulator/include/IbInputSimulator/SendTypes/DD.hpp
@@ -4,7 +4,7 @@
 #include "base.hpp"
 
 namespace Send::Type::Internal {
-    class DD final : virtual public Base, public VirtualKeyStates {
+    class DD final : public VirtualKeyStates {
         KeyboardModifiers modifiers;
         std::mutex keyboard_mutex;
 


### PR DESCRIPTION
Hotfix for #16 , actually I missed that DD also got the same problem which now fails the build
Error	C2584	'Send::Type::Internal::DD': direct base 'Send::Type::Internal::Base' is inaccessible; already a base of 'Send::Type::Internal::VirtualKeyStates'

