### PR TITLE
Fixing mouse move input for Logitech driver and fixing API 3 mouse move

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A library for simulating keyboard and mouse input with drivers.
 
 - [Logitech G HUB](https://www.logitechg.com/innovation/g-hub.html)
 
-  No Logitech hardware required. However, in the new versions of G HUB, the mouse driver has been removed ([#8](https://github.com/Chaoses-Ib/IbInputSimulator/issues/8)). Unfortunately, there is currently no known way to install an old version.
+  No Logitech hardware required.
 
   e.g. `IbSendInit("Logitech")`
 

--- a/Simulator/include/IbInputSimulator/SendTypes/Logitech.hpp
+++ b/Simulator/include/IbInputSimulator/SendTypes/Logitech.hpp
@@ -125,13 +125,13 @@ namespace Send::Type::Internal {
                 MouseButton button;
                 Byte button_byte;
             };
-            int8_t x;
-            int8_t y;
+            int16_t x;
+            int16_t y;
             Byte unknown_W;  //#TODO: Wheel?
             Byte unknown_T;  //#TODO: T?
         private:
             void assert_size() {
-                static_assert(sizeof MouseReport == 5);
+                static_assert(sizeof MouseReport == 8);
             }
         };
 
@@ -269,17 +269,17 @@ namespace Send::Type::Internal {
                     mouse_screen_to_relative(move);
                 }
 
-                while (abs(move.x) > 127 || abs(move.y) > 127) {
-                    if (abs(move.x) > 127) {
-                        mouse_report.x = move.x > 0 ? 127 : -127;
+                while (abs(move.x) > SHRT_MAX || abs(move.y) > SHRT_MAX) {
+                    if (abs(move.x) > SHRT_MAX) {
+                        mouse_report.y = move.x > 0 ? SHRT_MAX : -SHRT_MAX;
                         move.x -= mouse_report.x;
                     }
                     else {
                         mouse_report.x = 0;
                     }
 
-                    if (abs(move.y) > 127) {
-                        mouse_report.y = move.y > 0 ? 127 : -127;
+                    if (abs(move.y) > SHRT_MAX) {
+                        mouse_report.y = move.y > 0 ? SHRT_MAX : -SHRT_MAX;
                         move.y -= mouse_report.y;
                     }
                     else {
@@ -289,8 +289,8 @@ namespace Send::Type::Internal {
                     driver.report_mouse(mouse_report, compensate_switch = -compensate_switch);
                 }
 
-                mouse_report.x = (uint8_t)move.x;
-                mouse_report.y = (uint8_t)move.y;
+                mouse_report.x = (int16_t)move.x;
+                mouse_report.y = (int16_t)move.y;
             } else {
                 mouse_report.x = 0;
                 mouse_report.y = 0;

--- a/Simulator/include/IbInputSimulator/SendTypes/Razer.hpp
+++ b/Simulator/include/IbInputSimulator/SendTypes/Razer.hpp
@@ -99,7 +99,6 @@ namespace Send::Type::Internal {
             RzControl control{ .type = RzControl::Type::Mouse };
 
             if (mi.dwFlags & MOUSEEVENTF_MOVE) {
-                POINT move{ mi.dx, mi.dy };
                 if (mi.dwFlags & MOUSEEVENTF_ABSOLUTE) {
                     control.mi.Flags = MOUSE_MOVE_ABSOLUTE;
                 }

--- a/Simulator/source/API 3.cpp
+++ b/Simulator/source/API 3.cpp
@@ -13,7 +13,7 @@ DLLAPI bool __stdcall IbSendMouseMove(uint32_t x, uint32_t y, Send::MoveMode mod
             .mouseData = 0,
             .dwFlags = [mode]() -> DWORD {
                 switch (mode) {
-                    case MoveMode::Absolute: return MOUSEEVENTF_ABSOLUTE;
+                    case MoveMode::Absolute: return MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE;
                     case MoveMode::Relative: return MOUSEEVENTF_MOVE;
                     default: assert(false);
                 }


### PR DESCRIPTION
I checked on the latest [G hub](https://www.logitechg.com/en-us/innovation/g-hub.html) and it looks like mouse driver is working.
I noticed that there is a problem in API 3 with mouse move Absolute, it is fully ignored by all senders
For some reason int8_t as LogitechDriver::MouseReport X and Y doesn't work. I didn't check the spec but when i changed it to the int16_t it started working as expected. Maybe they changed sth in new release, idk. But regarding the readme it didn't work before, so I don't think that it is a big deal to change it since it is working.
There was also a problem with Logitech:
mouse_report... = (uint8_t)move...;
It ignored negative values.