### PR TITLE
Fixing Razer mouse movement vertically

### DIFF
--- a/Simulator/include/IbInputSimulator/SendTypes/Razer.hpp
+++ b/Simulator/include/IbInputSimulator/SendTypes/Razer.hpp
@@ -106,7 +106,7 @@ namespace Send::Type::Internal {
                     control.mi.Flags |= MOUSE_VIRTUAL_DESKTOP;
                 }
                 control.mi.LastX = mi.dx;
-                control.mi.LastY = mi.dy;
+                control.mi.LastY = (LONG)std::round(mi.dy / 1.2);
             }
 
             if (mi.dwFlags & MOUSEEVENTF_LEFTDOWN)


### PR DESCRIPTION
After moving the cursor to pos 1000,1000 mouse actually moves to 1000,1200, it looks like there is some multiplier applied. If I move the mouse with the default SendInput everything works as expected.