### PR TITLE
Adding static library build option

### DIFF
--- a/Simulator/CMakeLists.txt
+++ b/Simulator/CMakeLists.txt
@@ -4,7 +4,13 @@ project(IbInputSimulator)
 
 option(BUILD_SHARED_LIBS "Build as shared library (DLL) instead of static library" ON)
 
-set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+# Default: MultiThreaded$<$<CONFIG:Debug>:Debug>DLL
+# BUILD_SHARED_LIBS is mainly for AHK, which uses MT. So we follow it.
+if(BUILD_SHARED_LIBS)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+endif()
 
 # IbWinCppLib
 include(FetchContent)
@@ -12,6 +18,7 @@ FetchContent_Declare(IbWinCpp
     GIT_REPOSITORY https://github.com/Chaoses-Ib/IbWinCppLib.git
     GIT_TAG        f630f0e3a2c757652298c626fcd52469e5d5bc81
 )
+
 # Save and restore BUILD_SHARED_LIBS to avoid affecting other dependencies
 set(_BUILD_SHARED_LIBS_SAVED ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)

--- a/Simulator/CMakeLists.txt
+++ b/Simulator/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.15)
 
 project(IbInputSimulator)
 
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+option(BUILD_SHARED_LIBS "Build as shared library (DLL) instead of static library" ON)
+
+set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 
 # IbWinCppLib
 include(FetchContent)
@@ -10,7 +12,11 @@ FetchContent_Declare(IbWinCpp
     GIT_REPOSITORY https://github.com/Chaoses-Ib/IbWinCppLib.git
     GIT_TAG        f630f0e3a2c757652298c626fcd52469e5d5bc81
 )
+# Save and restore BUILD_SHARED_LIBS to avoid affecting other dependencies
+set(_BUILD_SHARED_LIBS_SAVED ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF)
 FetchContent_MakeAvailable(IbWinCpp)
+set(BUILD_SHARED_LIBS ${_BUILD_SHARED_LIBS_SAVED})
 
 # Detours
 find_path(DETOURS_INCLUDE_DIR detours/detours.h)
@@ -26,9 +32,16 @@ set(sourceFiles
     "API 3.cpp"
 )
 list(TRANSFORM sourceFiles PREPEND source/)
-add_library(IbInputSimulator SHARED ${sourceFiles})
+
+if(BUILD_SHARED_LIBS)
+    add_library(IbInputSimulator SHARED ${sourceFiles})
+    target_compile_definitions(IbInputSimulator PRIVATE IB_INPUT_DLLEXPORT)
+else()
+    add_library(IbInputSimulator STATIC ${sourceFiles})
+    target_compile_definitions(IbInputSimulator PRIVATE IB_INPUT_STATIC)
+endif()
+
 target_compile_features(IbInputSimulator PUBLIC cxx_std_20)
-target_compile_definitions(IbInputSimulator PRIVATE IB_INPUT_DLLEXPORT)
 
 set(PROJECT_VERSION_MAJOR 0)
 set(PROJECT_VERSION_MINOR 4)

--- a/Simulator/include/IbInputSimulator/InputSimulator.hpp
+++ b/Simulator/include/IbInputSimulator/InputSimulator.hpp
@@ -2,10 +2,12 @@
 #include <Windows.h>
 #include <stdint.h>
 
-#ifdef IB_INPUT_DLLEXPORT
-#define DLLAPI extern "C" __declspec(dllexport)
+#ifdef IB_INPUT_STATIC
+    #define DLLAPI extern "C"
+#elif defined(IB_INPUT_DLLEXPORT)
+    #define DLLAPI extern "C" __declspec(dllexport)
 #else
-#define DLLAPI extern "C" __declspec(dllimport)
+    #define DLLAPI extern "C" __declspec(dllimport)
 #endif
 
 namespace Send {
@@ -117,7 +119,7 @@ namespace Send {
         bool LAlt : 1;    //0x04
         bool LWin : 1;    //0x08
         bool RCtrl : 1;   //0x10
-        bool RShift : 1;  //0x20  
+        bool RShift : 1;  //0x20
         bool RAlt : 1;    //0x40
         bool RWin : 1;    //0x80
     };

--- a/Simulator/source/dllmain.cpp
+++ b/Simulator/source/dllmain.cpp
@@ -3,6 +3,7 @@ using namespace Send;
 
 #include <IbInputSimulator/SendTypes/types.hpp>
 
+#ifdef IB_INPUT_DLLEXPORT
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
                        LPVOID lpReserved
@@ -22,6 +23,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
     }
     return TRUE;
 }
+#endif
 
 namespace main {
     static std::unique_ptr<Type::Base> send;

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ cmake --build . --config Release
 
 ### Build as a static library
 
-You need to add `-BUILD_SHARED_LIBS=ON` when calling `cmake ..` .
+You need to add `-BUILD_SHARED_LIBS=OFF` when calling `cmake ..` .
 
 Also you need to add a preprocessor definition to your project: `IB_INPUT_STATIC`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,14 @@ cmake .. -DCMAKE_TOOLCHAIN_FILE="C:\...\vcpkg\scripts\buildsystems\vcpkg.cmake" 
 cmake --build . --config Release
 ```
 
+### Build as a static library
+
+You need to add `-BUILD_SHARED_LIBS=ON` when calling `cmake ..` .
+
+Also you need to add a preprocessor definition to your project: `IB_INPUT_STATIC`.
+
+### Test build
+
 For the test you also need:
 ```
 vcpkg install boost-test fmt


### PR DESCRIPTION
Enabled via adding `-BUILD_SHARED_LIBS=ON` to `cmake ..` 
To enable correct linkage in other project require a preprocessor definition `IB_INPUT_STATIC`
By default, the library builds in dynamic mode.

Resolves #48 